### PR TITLE
Support multilang category names.

### DIFF
--- a/index.php
+++ b/index.php
@@ -63,7 +63,8 @@ if ($mform->is_cancelled()) {
         )
     );
     \core\task\manager::queue_adhoc_task($task);
-    redirect($returnurl, get_string('updatequeued', 'tool_coursedates', $category->name));
+    redirect($returnurl, get_string('updatequeued', 'tool_coursedates',
+        format_string($category->name, true, array('context' => $context))));
 } else {
     // Prepare the form.
     $mform->set_data(array('category' => $categoryid));


### PR DESCRIPTION
A category name "{mlang de}Archiv{mlang}{mlang fr}Archives{mlang}{mlang en}Archives{mlang}{mlang it}Archivio{mlang}{mlang es}Archivo{mlang} 17"
is valid and if you've got the multilang2 plugin installed and activated behaves perfectly.

You could support such category names by accepting this pull request.

Best,
Luca